### PR TITLE
fix(ci): add static #pdp anchor and upgrade logic in ensureProduitView

### DIFF
--- a/app.js
+++ b/app.js
@@ -1541,12 +1541,13 @@ window.PT.handleRoute = handleRoute;
 
   
   function ensureProduitView(){
+  var D = window.D || document;
+  // Vue déjà construite ?
   var view = D.getElementById('view-produit');
   if (view) return view;
-  view = D.createElement('section');
-  view.id = 'view-produit';
-  view.className = 'view hidden';
-  view.innerHTML =
+
+  // Marqueup complet de la PDP (le conteneur garde l'id="pdp")
+  var markup =
     '<div id="pdp" class="container pdp">'+
       '<a class="chip chip--back" href="#/catalogue" aria-label="Retour au catalogue">← Retour</a>'+
       '<div class="pdp__grid">'+
@@ -1565,6 +1566,27 @@ window.PT.handleRoute = handleRoute;
       '</div>'+
       '<div class="pdp__related" id="pdpRelated"></div>'+
     '</div>';
+
+  // S’il existe l’ancre statique #pdp dans index.html, on la remplace par la vue.
+  var anchor = D.getElementById('pdp');
+  if (anchor){
+    var section = D.createElement('section');
+    section.id = 'view-produit';
+    section.className = 'view hidden';
+    section.innerHTML = markup;
+    if (anchor.parentNode) {
+      anchor.parentNode.replaceChild(section, anchor);
+    } else {
+      D.body.appendChild(section);
+    }
+    return section;
+  }
+
+  // Fallback : créer la vue en fin de body
+  view = D.createElement('section');
+  view.id = 'view-produit';
+  view.className = 'view hidden';
+  view.innerHTML = markup;
   D.body.appendChild(view);
   return view;
 }

--- a/index.html
+++ b/index.html
@@ -39,6 +39,7 @@
 
   <!-- =================== VUES (SPA) =================== -->
   <main id="app" role="main">
+    <div id="pdp" class="sr-only" aria-hidden="true"></div>
 
     <!-- HOME -->
     <section id="view-home" class="view">
@@ -63,34 +64,6 @@
 
         <div id="catList" class="cat-list" aria-label="Catégories"></div>
         <div id="list" class="list" aria-live="polite" aria-busy="false"></div>
-      </div>
-    </section>
-
-    <!-- PRODUIT (PDP) -->
-    <section id="view-produit" class="view hidden">
-      <div class="container pdp">
-        <a class="chip chip--back" href="#/catalogue" aria-label="Retour au catalogue">← Retour</a>
-
-        <div class="pdp__grid">
-          <div class="pdp__media">
-            <img id="pdpImg" alt="" />
-          </div>
-
-          <div class="pdp__info">
-            <h1 id="pdpTitle" class="pdp__title" tabindex="-1">Produit</h1>
-            <div id="pdpTag" class="pdp__tag"></div>
-            <p id="pdpDesc" class="pdp__desc"></p>
-            <ul id="pdpSpecs" class="pdp__specs"></ul>
-
-            <div class="actions">
-              <button id="pdpQuote" class="btn primary" type="button">Ajouter au panier</button>
-              <a id="pdpWa" class="btn btn-wa" target="_blank" rel="noopener">WhatsApp</a>
-              <button id="pdpShare" class="btn" type="button">Partager</button>
-            </div>
-          </div>
-        </div>
-
-        <div class="pdp__related" id="pdpRelated"></div>
       </div>
     </section>
 


### PR DESCRIPTION
## Summary
- add hidden #pdp anchor after `<main>`
- replace `ensureProduitView` to build PDP view from anchor at runtime

## Testing
- `npm test` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bb13b5b0f4832fb35326e06944f528