### PR TITLE
chore(ci): add valid package.json for CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "pirates-tools-app1",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Static PWA for Pirates Tools. CI runs node scripts/ci.js to validate anchors/assets.",
+  "scripts": {
+    "test": "node scripts/ci.js"
+  },
+  "engines": {
+    "node": ">=18.18.0"
+  },
+  "license": "UNLICENSED"
+}


### PR DESCRIPTION
## Summary
- add valid `package.json` to enable CI via `npm test`

## Testing
- `npm test` *(fails: id="#pdp" introuvable; image paths not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb2fae8ec8832faf4b0ea476a50336