### PR TITLE
chore(ci): restore valid package.json so npm test starts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "pirates-tools-app1",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Static PWA for Pirates Tools. CI runs node scripts/ci.js to validate anchors/assets.",
+  "scripts": {
+    "test": "node scripts/ci.js"
+  },
+  "engines": {
+    "node": ">=18.18.0"
+  },
+  "license": "UNLICENSED"
+}


### PR DESCRIPTION
## Summary
- restore valid package.json so npm test starts

## Testing
- `npm test`

## Audit
- package.json path: `./package.json`
- size before fix: 0 bytes; first 3 lines: *(file was empty)*
- scripts/ci.js: present
- .github/workflows/ci.yml: present


------
https://chatgpt.com/codex/tasks/task_e_68bb3b9d1a98832f877d967936e4bafe