### PR TITLE
chore(ci): restore valid package.json for CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "pirates-tools-app1",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Static PWA for Pirates Tools. CI runs node scripts/ci.js to validate anchors/assets.",
+  "scripts": {
+    "test": "node scripts/ci.js"
+  },
+  "engines": {
+    "node": ">=18.18.0"
+  },
+  "license": "UNLICENSED"
+}


### PR DESCRIPTION
## Summary
- restore valid package.json so CI can run `npm run test`

## Testing
- `npm run test` (fails: id="#pdp" introuvable., Chemin image introuvable: ./images/pirates-tools-logo.png?v=7, Chemin image introuvable: ./images/brands/Logo.milwaukee.png, Chemin image introuvable: ./images/brands/Logo.makita.png, Chemin image introuvable: ./images/brands/Logo.wera.png, Chemin image introuvable: ./images/pirates-tools-logo.png?v=7\)

------
https://chatgpt.com/codex/tasks/task_e_68bb4321d6b0832f999b13df2be6504c