### PR TITLE
chore(ci): inline site logo & add #pdp anchor

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Pirates Tools • Outillage pro (PWA)</title>
   <meta name="description" content="Pirates Tools — Visseuses à chocs DeWALT, dispo Antilles. PWA rapide, contact immédiat (téléphone & WhatsApp)." />
-  <!-- ⛔ supprimé: preload image manquante ./images/pirates-tools-logo.png?v=7 -->
+  <!-- preload du logo fichier supprimé: on utilise un data URI inline -->
   <link rel="stylesheet" href="./styles.css" />
 </head>
 <body>
@@ -21,13 +21,11 @@
       </button>
 
       <a id="homeLink" class="topbar-logo-link" href="#">
-        <!-- ✅ logo inline: plus de chemin cassé -->
-        <svg class="topbar-logo" width="140" height="40" viewBox="0 0 140 40" role="img" aria-label="Pirates Tools">
-          <rect x="0" y="0" width="140" height="40" rx="8" ry="8" fill="#0bd1ff"></rect>
-          <text x="50%" y="50%" font-size="18" font-weight="700" text-anchor="middle"
-                dominant-baseline="middle" fill="#001018"
-                font-family="system-ui,-apple-system,Segoe UI,Roboto,Arial">Pirates&nbsp;Tools</text>
-        </svg>
+        <img
+          class="topbar-logo"
+          alt="Pirates Tools"
+          src="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 256 64'><rect width='256' height='64' rx='8' ry='8' fill='%23121b24'/><text x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-family='Arial,Helvetica,sans-serif' font-size='22' fill='%23e6edf5'>Pirates Tools</text></svg>"
+        />
       </a>
     </div>
 
@@ -39,18 +37,12 @@
 
   <!-- =================== HERO =================== -->
   <section id="hero" class="hero-full" aria-hidden="true">
-    <!-- ✅ image remplacée par SVG inline -->
-    <svg id="heroLogo" class="hero-logo" viewBox="0 0 140 40" role="img" aria-label="">
-      <defs>
-        <linearGradient id="pt-grad" x1="0" y1="0" x2="1" y2="1">
-          <stop offset="0" stop-color="#0bd1ff"/><stop offset="1" stop-color="#49f2c2"/>
-        </linearGradient>
-      </defs>
-      <rect x="0" y="0" width="140" height="40" rx="8" ry="8" fill="url(#pt-grad)"></rect>
-      <text x="50%" y="50%" font-size="18" font-weight="700" text-anchor="middle"
-            dominant-baseline="middle" fill="#001018"
-            font-family="system-ui,-apple-system,Segoe UI,Roboto,Arial">Pirates&nbsp;Tools</text>
-    </svg>
+    <img
+      id="heroLogo"
+      class="hero-logo"
+      alt=""
+      src="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 128'><rect width='512' height='128' fill='%23121b24'/><text x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-family='Arial,Helvetica,sans-serif' font-size='48' fill='%23e6edf5'>Pirates Tools</text></svg>"
+    />
     <div class="hero-fade"></div>
   </section>
 
@@ -163,9 +155,6 @@
       </div>
     </section>
 
-    <!-- ✅ ancre requise par la CI -->
-    <a id="pdp" class="sr-only" aria-hidden="true"></a>
-
   </main>
 
   <!-- =================== DOCK =================== -->
@@ -200,12 +189,15 @@
     </a>
   </aside>
 
-  <!-- =================== TOASTS + A11y roots (les scripts les créent si absents) =================== -->
+  <!-- =================== TOASTS + A11y roots =================== -->
   <div id="toasts" aria-live="polite"></div>
   <div id="sr-live" class="sr-only" aria-live="polite"></div>
 
   <!-- Bouton d’installation PWA (révélé par JS si pertinent) -->
   <button id="installBtn" class="chip hidden" hidden>Installer l’app</button>
+
+  <!-- Ancre exigée par la CI -->
+  <div id="pdp" class="sr-only" hidden></div>
 
   <noscript>
     <div style="padding:1rem;margin:1rem;border:1px solid #22303b;border-radius:8px;background:#121b24;color:#e6edf5">
@@ -216,7 +208,7 @@
   <!-- =================== JS =================== -->
   <script src="./app.js" defer></script>
 
-  <!-- Micro-script menu (non intrusif, compatible avec vos styles) -->
+  <!-- Micro-script menu -->
   <script>
     (function(){
       var btn = document.getElementById('menu-toggle');


### PR DESCRIPTION
## Summary
- inline SVG logos with data URIs to avoid missing file paths
- add hidden `#pdp` anchor required by CI

## Testing
- `npm test` *(fails: Chemin image introuvable: ./images/pirates-tools-logo.png?v=7)*

------
https://chatgpt.com/codex/tasks/task_e_68bb4b7e4a00832f9d0485f7872c889b